### PR TITLE
binwrap crashes when upgrading package

### DIFF
--- a/binstall.js
+++ b/binstall.js
@@ -42,7 +42,9 @@ function untgz(url, path, options) {
       reject("Error decompressing " + url + " " + error);
     });
 
-    fs.mkdirSync(path);
+    if (!fs.existsSync(path)) {
+      fs.mkdirSync(path);
+    }
 
     request
       .get(url, function(error, response) {


### PR DESCRIPTION
After upgrading ava, elm & elm-test to the latest versions `yarn upgrade some_internal_package` fails with
```
ERR { Error: EEXIST: file already exists, mkdir '/Volumes/Development/code/project_folder/node_modules/elmi-to-json/unpacked_bin'
    at Object.mkdirSync (fs.js:752:3)
    at /Volumes/Development/code/login/node_modules/binwrap/binstall.js:45:8
    at new Promise (<anonymous>)
    at untgz (/Volumes/Development/code/login/node_modules/binwrap/binstall.js:21:10)
    at binstall (/Volumes/Development/code/login/node_modules/binwrap/binstall.js:11:12)
    at install (/Volumes/Development/code/login/node_modules/binwrap/install.js:20:10)
    at Object.install (/Volumes/Development/code/login/node_modules/binwrap/index.js:14:14)
    at Object.<anonymous> (/Volumes/Development/code/login/node_modules/binwrap/bin/binwrap-install:18:9)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
  errno: -17,
  syscall: 'mkdir',
```

The `some_internal_package ` also has some updated packages, but that package has no code or dependencies related to elm.
