### PR TITLE
Wrapped the mkdirSync with a try/catch

### DIFF
--- a/binstall.js
+++ b/binstall.js
@@ -42,7 +42,11 @@ function untgz(url, path, options) {
       reject("Error decompressing " + url + " " + error);
     });
 
-    fs.mkdirSync(path);
+    try {
+      fs.mkdirSync(path);
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+    }
 
     request
       .get(url, function(error, response) {


### PR DESCRIPTION
Wrapped the mkdirSync with existsSync to prevent `file already exists…` exception

it may fix: 

https://github.com/avh4/binwrap/issues/29
https://github.com/avh4/elm-format/issues/602